### PR TITLE
assigning error handler the right way

### DIFF
--- a/imgee/__init__.py
+++ b/imgee/__init__.py
@@ -32,18 +32,18 @@ def mkdir_p(dirname):
         os.makedirs(dirname)
 
 
-def error403(error):
-    return redirect(url_for('login'))
-
-
 # Configure the app
 
 coaster.app.init_app(app)
 migrate = Migrate(app, db)
 baseframe.init_app(app, requires=['baseframe', 'picturefill', 'imgee'])
-app.error_handlers[403] = error403
 lastuser.init_app(app)
 lastuser.init_usermanager(UserManager(db, models.User))
+
+
+@app.errorhandler(403)
+def error403(error):
+    return redirect(url_for('login'))
 
 if app.config.get('MEDIA_DOMAIN') and (
         app.config['MEDIA_DOMAIN'].startswith('http:') or

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,7 @@ import random
 import string
 
 from flask import g
-from imgee import init_for, app, storage
+from imgee import app, storage
 from imgee.models import db, User, Profile, StoredFile
 
 
@@ -22,7 +22,6 @@ def get_test_user(name, id=1):
 
 class ImgeeTestCase(unittest.TestCase):
     def setUp(self):
-        init_for('testing')
         app.config['TESTING'] = True
         app.testing = True
         db.create_all()


### PR DESCRIPTION
This has been causing imgee production to throw the error last few days. The method to assign error handler changed in 0.11. Hence it was breaking since the upgrade to 0.12. This fixes it.